### PR TITLE
Added Dockerfile to Simplify Deployment

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -1,0 +1,26 @@
+# sync with https://github.com/fphammerle/docker-onion-service/blob/master/.github/workflows/container-image.yml
+
+name: container image
+
+on:
+  push:
+  pull_request:
+  schedule:
+  - cron: '0 20 * * 5'
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: docker/setup-qemu-action@v1.2.0
+    - uses: docker/setup-buildx-action@v1.3.0
+    # > By default, this action uses the Git context so you don't need to use
+    # > the actions/checkout action to checkout the repository because this
+    # > will be done directly by buildkit. [...]
+    # > any file mutation in the steps that precede [...] will be ignored
+    # https://github.com/marketplace/actions/build-and-push-docker-images
+    - uses: docker/build-push-action@v2.5.0
+      with:
+        platforms: |
+          linux/amd64
+          linux/arm/v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM alpine:3.10 as build
+
+RUN apk add --no-cache \
+    cmake \
+    gcc \
+    git \
+    libmilter-dev \
+    make \
+    musl-dev
+
+COPY . /milterfrom
+
+WORKDIR /milterfrom
+
+RUN mkdir build \
+    && cd build \
+    && cmake -DWITH_SYSTEMD=OFF .. \
+    && make
+
+
+FROM alpine:3.10 as service
+
+RUN adduser -S milterfrom \
+    && apk add libmilter
+
+COPY --from=build /milterfrom/build/milterfrom /usr/local/bin/
+
+USER milterfrom
+
+EXPOSE 8890/tcp
+
+CMD ["milterfrom", "-s", "inet:8890"]

--- a/README.md
+++ b/README.md
@@ -87,5 +87,14 @@ To start the daemon directly, run the following (Remove the `-d` to run in foreg
 milterfrom -u milterfrom -g milterfrom -m 002 -d -p /var/run/milterfrom.pid -s /var/spool/postfix/milterfrom/milterfrom
 ```
 
+## Run via Docker
+
+```bash
+docker build -t milterfrom .
+docker run --restart=unless-stopped --daemon --name milterfrom milterfrom:latest
+postconf -e "smtpd_milters = tcp:milterfrom:8890$([[ $(postconf -h smtpd_milters) != "" ]] && echo -n ", " && postconf -h smtpd_milters)"
+postconf -e "non_smtpd_milters = tcp:milterfrom:8890$([[ $(postconf -h non_smtpd_milters) != "" ]] && echo -n ", " && postconf -h non_smtpd_milters)"
+```
+
 ## License
 Licensed under the 3-Clause BSD License.


### PR DESCRIPTION
Thanks for sharing `milterfrom`.

I added a Dockerfile to build and run the milter service.

Advantages of dockerized vs. conventional build/service:
* Easy build via single `docker build` command
* No build & runtime dependencies (except from docker daemon)
* Easy deployment via ansible playbook (and other provisioning tools)

```ansible
# ansible sample playbook
- hosts: [mail1, mail2, mail3]
  become: true
  tasks:
  # ...
  - name: milterfrom
    docker_container:
      name: milterfrom
      image: fphammerle/magcksmilterfrom@sha256:d3ed5ea252f198925f2ead378319794c66ab483ae85d2cf9ebe51ecddf8b27c5
      networks: [name: mail]
      purge_networks: yes
      memory: 16M
      restart_policy: always
  - name: create postfix config
    copy:
      content: |
        milter_default_action = accept
        milter_protocol = 2
        smtpd_milters = inet:milterfrom:8890, inet:opendkim:8891
        non_smtpd_milters = inet:milterfrom:8890, inet:opendkim:8891
        # ...
```

I thought others might find this approach useful, so a created a PR :-)