### PR TITLE
Fix segfault on empty envelope from or alloc failure

### DIFF
--- a/src/milterfrom.c
+++ b/src/milterfrom.c
@@ -130,6 +130,8 @@ sfsistat mlfi_header(SMFICTX *ctx, char *headerf, char *headerv)
 {
 	struct mlfiPriv *priv = MLFIPRIV;
 
+	if (priv == NULL) return SMFIS_CONTINUE;
+
 	// Perform checks if the sender is authenticated and the message is not rejected yet (the mail may contain multiple from tags, all have to match!).
 	if (priv->is_auth && !priv->reject) {
 		if (strcasecmp(headerf, "from") == 0) {
@@ -147,6 +149,9 @@ sfsistat mlfi_header(SMFICTX *ctx, char *headerf, char *headerv)
 sfsistat mlfi_eom(SMFICTX *ctx)
 {
 	struct mlfiPriv *priv = MLFIPRIV;
+
+	if (priv == NULL) return SMFIS_CONTINUE;
+
 	if (priv->reject) {
 		smfi_setreply(ctx, "550", "5.7.1", "Rejected due to unmatching envelope and header sender.");
 		mlfi_cleanup(ctx);


### PR DESCRIPTION
`mlfi_envfrom` can return early, without setting `mlfiPriv`. This is due to two branches:

```
        // Parse envelope from.
	size_t len = 0;
	const char *from = parse_address(*envfrom, &len);
	if (len == 0) {
		/* A 0 length from address means a "null reverse-path", which is valid per
		 * RFC5321. */
		return SMFIS_CONTINUE;
	}
	fromcp = strndup(from, len);
	if (fromcp == NULL) {
		return SMFIS_TEMPFAIL;
	}
```

both of these branches return without calling `smfi_setpriv(ctx, priv);`

This causes a later segfault in either `mlfi_eom` or `mlfi_header`, because those access `MLFIPRIV` unchecked. This causes a segmentation fault (null pointer derefence), if one of the above branches was taken.

Fix removes the assumption that `MLFIPRIV` is not null and simply aborts processing if that is the case.