### PR TITLE
Updates/version 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 #milterfrom CHANGELOG
 
-Version 1.0.1  2023-08-30
+Version 1.0.4 2025-10-05
+* Added optional argument `-r` to reject on multiple From: address fields like From:Grouping<g@example> <auth@example.com>
+* Added optional argument `-n`  to reject null sender unless authentication matches the From: address.
+* See CERT/CC disclosure VU#517845 kb.cert.org/vuls/id/517845
 
-* Add logging to log mismatch event using syslog (mail.notice)
-* Add VERSION declaration and help/version command line options
-* Add CHANGELOG.md to repository for tracking
+
+Version 1.0.3 2025-09-24
+* Added verification of no control characters inside carrots.
+[See references https://blog.slonser.info/posts/email-attacks/ ]
 
 Version 1.0.2  2023-09-18
 
@@ -12,10 +16,10 @@ Version 1.0.2  2023-09-18
 * Added syslog on null sender event with connection details (IP,name)
 * Changed syslog to be from log_event routine
 
-Version 1.0.3 2025-09-24
-* Added verification of no control characters inside carrots.
-[See references https://blog.slonser.info/posts/email-attacks/ ]
+Version 1.0.1  2023-08-30
 
-Version 1.0.4 2025-10-05
-* Added option to reject on multiple From: address fields like From:Grouping<g@example> <auth@example.com>
-* This requires use of optional `-r` argument for blocking
+* Add logging to log mismatch event using syslog (mail.notice)
+* Add VERSION declaration and help/version command line options
+* Add CHANGELOG.md to repository for tracking
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,7 @@ Version 1.0.2  2023-09-18
 Version 1.0.3 2025-09-24
 * Added verification of no control characters inside carrots.
 [See references https://blog.slonser.info/posts/email-attacks/ ]
+
+Version 1.0.4 2025-10-05
+* Added option to reject on multiple From: address fields like From:Grouping<g@example> <auth@example.com>
+* This requires use of optional `-r` argument for blocking

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(MilterFrom C)
 

--- a/src/milterfrom.c
+++ b/src/milterfrom.c
@@ -220,7 +220,7 @@ sfsistat mlfi_header(SMFICTX *ctx, char *headerf, char *headerv)
 				msg_len = 55 + len + priv->env_from_len;
 				msg = malloc(msg_len);
 				if (msg != NULL) { 
-				  snprintf(msg, msg_len, "Rejecting Envelope From (%s) and Header From (%s) mismatch", priv->env_from ? priv->env_from : "(null)", from ? from : "(null)");
+					snprintf(msg, msg_len, "Rejecting Envelope From (%s) and Header From (%s) mismatch", priv->env_from ? priv->env_from : "(null)", from ? from : "(null)");
 					log_event(ctx, msg);
 				}
 				free(msg);

--- a/src/milterfrom.c
+++ b/src/milterfrom.c
@@ -98,7 +98,7 @@ const char *parse_address(SMFICTX *ctx, const char *header, size_t *len) {
       start = header + i + 1; // Last '<'
     } else if (header[i] == '>') {
       if (!start) {
-	log_event(ctx, "Unmatched carrot < seen in header");
+	log_event(ctx, "Unmatched angle bracket < seen in header");
 	return NULL; // unmatched '>'
       }
       if (end) {

--- a/src/milterfrom.c
+++ b/src/milterfrom.c
@@ -86,21 +86,21 @@ const char *parse_address(SMFICTX *ctx, const char *header, size_t *len) {
 
   const char *start = NULL;
   const char *end = NULL;
-  int open_count = 0;
+  int caret_count = 0;
   size_t i;
 
   /* Scan for angle brackets */
   for (i = 0; header[i]; i++) {
     if (header[i] == '<') {
-      open_count++;
+      caret_count++;
       start = header + i + 1; // Last '<'
     } else if (header[i] == '>') {
       if (!start) {
-	log_event(ctx, "Unmatched carrot < seen in header");
+	log_event(ctx, "Unmatched caret < seen in header");
 	return NULL; // unmatched '>'
       }
       if (end) {
-	open_count++;
+	caret_count++;
       }
       end = header + i;
     }
@@ -109,7 +109,7 @@ const char *parse_address(SMFICTX *ctx, const char *header, size_t *len) {
   /* Angle-bracketed address */
   if (start || end) {
     if (!start || !end) return NULL;   // unmatched brackets
-    if (reject_multiple_from && open_count != 1) {
+    if (reject_multiple_from && caret_count != 1) {
       log_event(ctx, "Rejecting due to multiple sender addresses embedded Grouping");
       return NULL;
     }
@@ -124,7 +124,7 @@ const char *parse_address(SMFICTX *ctx, const char *header, size_t *len) {
     /* Reject control characters */
     for (const char *p = start; p < end; p++) {
       if ((unsigned char)*p < 32 || *p == 127) {
-	log_event(ctx, "Rejecting due to non-ascii characters found inside email address");
+	log_event(ctx, "Rejecting due to control characters found inside email address");
 	return NULL;
       }
     }
@@ -341,8 +341,8 @@ int main(int argc, char **argv)
 			um = strtol(optarg, 0, 8);
 			break;
 		case 'r':   /* --reject-multi-from */
-		        reject_multiple_from = 1;
-		        break;
+                        reject_multiple_from = 1;
+                        break;
 		case 'h':
 			usage(stdout);
 			return EXIT_SUCCESS;

--- a/src/milterfrom.c
+++ b/src/milterfrom.c
@@ -71,7 +71,7 @@ void log_event(SMFICTX *ctx, char *msg) {
 	/* Log event with additional information */
 	const char *author = smfi_getsymval(ctx, "{auth_authen}");
 	const char *info = smfi_getsymval(ctx,"_");
-	syslog(LOG_INFO,"%s for authenticated user (%s) from (%s)", msg, author ? author : "(null)", info);
+	syslog(LOG_INFO,"%s for authenticated user (%s) from (%s)", msg, author ? author : "(null)", info ? info : "(null)");
 }
 
 

--- a/src/milterfrom.c
+++ b/src/milterfrom.c
@@ -46,6 +46,8 @@
 #include <ctype.h>
 #include <stddef.h>
 
+// Assume stdbool.h is there. c99 was 27 years ago...
+#define SM_CONF_STDBOOL_H 1
 #include "libmilter/mfapi.h"
 #include "libmilter/mfdef.h"
 


### PR DESCRIPTION
This addresses a number of concerns raised by https://kb.cert.org/vuls/id/517845 on Grouping and other. The new options are summarized below by Copilot chatbot for convenience and clarity.

This pull request introduces several new security and configuration options to the `milterfrom` project, primarily focused on improving the handling of sender address validation and strengthening protections against email spoofing techniques. It adds two new command-line options for stricter From: header enforcement, updates the address parsing logic to support these checks, and enhances logging for better traceability of rejection reasons.

**Key changes:**

**Security and validation enhancements:**
* Added `-r` option to reject emails with multiple From: addresses (such as grouping syntax) by detecting multiple angle brackets in the header, helping mitigate spoofing attempts. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R25) [[2]](diffhunk://#diff-957a7543208582a6c0f7cb0d20a7d119bf092f92831be12290bfe4f66163b311R59-R138) [[3]](diffhunk://#diff-957a7543208582a6c0f7cb0d20a7d119bf092f92831be12290bfe4f66163b311R318-R322) [[4]](diffhunk://#diff-957a7543208582a6c0f7cb0d20a7d119bf092f92831be12290bfe4f66163b311L294-R338) [[5]](diffhunk://#diff-957a7543208582a6c0f7cb0d20a7d119bf092f92831be12290bfe4f66163b311L311-R363)
* Added `-n` option to reject emails with a null envelope sender unless the authenticated username matches the From: header, providing stricter enforcement for authenticated senders. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R25) [[2]](diffhunk://#diff-957a7543208582a6c0f7cb0d20a7d119bf092f92831be12290bfe4f66163b311R59-R138) [[3]](diffhunk://#diff-957a7543208582a6c0f7cb0d20a7d119bf092f92831be12290bfe4f66163b311L180-R237) [[4]](diffhunk://#diff-957a7543208582a6c0f7cb0d20a7d119bf092f92831be12290bfe4f66163b311R318-R322) [[5]](diffhunk://#diff-957a7543208582a6c0f7cb0d20a7d119bf092f92831be12290bfe4f66163b311L294-R338) [[6]](diffhunk://#diff-957a7543208582a6c0f7cb0d20a7d119bf092f92831be12290bfe4f66163b311L311-R363)
* Improved `parse_address` function to detect and reject multiple address groupings and control/non-ASCII characters inside addresses, and to log detailed rejection reasons. [[1]](diffhunk://#diff-957a7543208582a6c0f7cb0d20a7d119bf092f92831be12290bfe4f66163b311R59-R138) [[2]](diffhunk://#diff-957a7543208582a6c0f7cb0d20a7d119bf092f92831be12290bfe4f66163b311L180-R237)

**Logging and diagnostics:**
* Enhanced `log_event` function to include more contextual information (authenticated user, connection info) and to be invoked on various rejection events for better diagnostics. [[1]](diffhunk://#diff-957a7543208582a6c0f7cb0d20a7d119bf092f92831be12290bfe4f66163b311R59-R138) [[2]](diffhunk://#diff-957a7543208582a6c0f7cb0d20a7d119bf092f92831be12290bfe4f66163b311L121-L127) [[3]](diffhunk://#diff-957a7543208582a6c0f7cb0d20a7d119bf092f92831be12290bfe4f66163b311L180-R237)

**Documentation and versioning:**
* Updated `CHANGELOG.md` to document new features, security improvements, and version bump to 1.0.4.
* Updated version string in `src/milterfrom.c` to reflect new release.

These changes collectively improve the robustness of sender validation and provide administrators with more control and visibility over how sender addresses are handled.